### PR TITLE
Add GitHub dev/release processes (CI, changelog, release script, PR template)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,6 @@
 /lib
 /index.js
 node_modules
+# Example apps pin 2019-era deps that don't install on current Node; they are
+# linted and tested within their own packages once those deps are modernized.
+examples

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## What Changed
+
+<!-- Describe the changes in this pull request -->
+
+## Why
+
+<!-- Why are these changes needed? Link to the relevant issue, e.g. Closes #123 -->
+
+## How to Test
+
+<!-- Steps to verify the changes -->
+
+1.
+2.
+3.
+
+## Checklist
+
+- [ ] Self-reviewed the code
+- [ ] Tests added or updated
+- [ ] Documentation updated (if needed)
+- [ ] CHANGELOG.md updated under "Unreleased"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  # Gating check: lint and test the published library across a Node matrix.
+  lib:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn lint
+      - run: yarn test
+
+  # MongoDB example app integration tests against a mongo service container.
+  #
+  # Non-gating (continue-on-error) for now: the example apps pin 2019-era
+  # native dependencies (bcrypt@3 via node-pre-gyp) that do not build on
+  # current Node. Once the example dependencies are modernized, drop
+  # continue-on-error so these become gating checks again.
+  example-mongo:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    services:
+      mongo:
+        image: mongo:latest
+        ports:
+          - 27017:27017
+
+    env:
+      TEST_DB_URL: mongodb://localhost:27017/test
+      SECRET_KEY: ci_secret
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      # The example consumes the built library (its pretest builds lib/).
+      - run: yarn install --frozen-lockfile
+      - run: yarn --cwd examples/mongo install --frozen-lockfile
+      - run: yarn --cwd examples/mongo test
+
+  # PostgreSQL example app integration tests against a postgres service
+  # container. Non-gating for the same reason as example-mongo above.
+  example-postgres:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: ci_db
+          POSTGRES_USER: ci_user
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      TEST_DB_HOST: localhost
+      TEST_DB_USERNAME: ci_user
+      TEST_DB_PASSWORD: ""
+      TEST_DB_DATABASE: ci_db
+      SECRET_KEY: ci_secret
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn --cwd examples/postgres install --frozen-lockfile
+      - run: yarn --cwd examples/postgres test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `CHANGELOG.md` following Keep a Changelog + Semantic Versioning.
+- GitHub Actions CI (`.github/workflows/ci.yml`): lints and tests the library
+  across a Node version matrix, and runs the MongoDB and PostgreSQL example
+  test suites against service containers.
+- `scripts/release.mjs` and a `release` script that cuts a GitHub release for
+  the version in `package.json` (publish-first), with notes pulled from this
+  changelog and the built `lib/` attached as `lib.zip`.
+- Pull request template (`.github/PULL_REQUEST_TEMPLATE.md`).
+- Explicit `types` and `files` fields in `package.json` so the published
+  package ships only `lib/` and `index.js`.
+
+### Changed
+
+- Reworked the MongoDB and PostgreSQL example test suites: database
+  connections are created and closed separately, a global setup clears the
+  database before runs, and shared test utilities are grouped on their own.
+
+## [0.1.0] - 2019-08-13
+
+### Added
+
+- Initial release: role-based access control for Express apps — permissions,
+  policies, and an `authorize` middleware, with MongoDB and PostgreSQL example
+  applications.
+
+[Unreleased]: https://github.com/mutaimwiti/rbactl/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/mutaimwiti/rbactl/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## rbactl
 
-[![build](https://gitlab.com/mutaimwiti/rbactl/badges/master/build.svg)](https://gitlab.com/mutaimwiti/rbactl/pipelines)
-[![coverage](https://gitlab.com/mutaimwiti/rbactl/badges/master/coverage.svg)](https://gitlab.com/mutaimwiti/rbactl/commits/master)
+[![build](https://github.com/mutaimwiti/rbactl/actions/workflows/ci.yml/badge.svg)](https://github.com/mutaimwiti/rbactl/actions/workflows/ci.yml)
 [![version](https://img.shields.io/npm/v/rbactl.svg)](https://www.npmjs.com/package/rbactl)
 [![downloads](https://img.shields.io/npm/dm/rbactl.svg)](https://www.npmjs.com/package/rbactl)
 [![license](https://img.shields.io/npm/l/rbactl.svg)](https://www.npmjs.com/package/rbactl)
@@ -11,7 +10,7 @@ apps. The library embraces the unopinionated and minimalist approach of express 
 frameworks built on top of express. Your app decides how to store and retrieve roles (plus permissions) and the
 authentication logic. The library only comes in to simplify the process of building your authorization logic.
 
-> Repo : [GitLab](https://gitlab.com/mutaimwiti/rbactl) | [GitHub](https://github.com/mutaimwiti/rbactl)
+> Repo : [GitHub](https://github.com/mutaimwiti/rbactl) | [GitLab (mirror)](https://gitlab.com/mutaimwiti/rbactl)
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "Easy and intuitive role-based access control library for Express apps.",
   "main": "index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "/lib",
+    "/index.js"
+  ],
   "directories": {
     "test": "test"
   },
@@ -12,6 +17,7 @@
     "test:watch": "jest --colors --watch",
     "build": "babel -d lib src/ && cp src/index.d.ts lib/index.d.ts",
     "lint": "eslint .",
+    "release": "node scripts/release.mjs",
     "prepublishOnly": "yarn clean && yarn build && yarn lint && yarn test"
   },
   "pre-commit": [
@@ -22,7 +28,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://gitlab.com/mutaimwiti/rbactl.git"
+    "url": "git+https://github.com/mutaimwiti/rbactl.git"
   },
   "keywords": [
     "rbac",
@@ -38,12 +44,12 @@
     "authorization",
     "express-authorization"
   ],
-  "author": "Mutai Mwiti",
+  "author": "Mutai Mwiti <mutaimwiti40@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://gitlab.com/mutaimwiti/rbactl/issues"
+    "url": "https://github.com/mutaimwiti/rbactl/issues"
   },
-  "homepage": "https://gitlab.com/mutaimwiti/rbactl#readme",
+  "homepage": "https://github.com/mutaimwiti/rbactl#readme",
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.3.4",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/*
+ * Cuts a GitHub release for the version currently in package.json, automating
+ * the manual post-publish steps:
+ *
+ *   1. confirm the working tree is clean and on the default branch
+ *   2. confirm that version is already published to npm (publish-first)
+ *   3. confirm the release/tag does not already exist
+ *   4. build lib/ and zip it to lib.zip (the release asset convention)
+ *   5. create the GitHub release (which creates the lightweight v<version> tag)
+ *      pinned to the current commit, with notes from the CHANGELOG, and attach
+ *      lib.zip
+ *
+ * This does NOT publish to npm; run `npm publish` first. Pass --dry-run to
+ * print the plan without creating anything.
+ *
+ * Usage: node scripts/release.mjs [--dry-run]
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, rmSync } from 'node:fs';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const DEFAULT_BRANCH = 'master';
+
+const log = (msg) => console.log(`[release] ${msg}`);
+const fail = (msg) => {
+  console.error(`[release] error: ${msg}`);
+  process.exit(1);
+};
+
+// Run a command, returning trimmed stdout. Throws on non-zero exit.
+const run = (cmd, args) =>
+  execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+
+// Run a command, returning { ok, out } instead of throwing.
+const tryRun = (cmd, args) => {
+  try {
+    return { ok: true, out: run(cmd, args) };
+  } catch (e) {
+    return { ok: false, out: `${e.stdout || ''}${e.stderr || ''}`.trim() };
+  }
+};
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const { name, version } = pkg;
+const tag = `v${version}`;
+
+// Derive the canonical repo URL from the repository field.
+const repoUrl = String(pkg.repository?.url || pkg.repository || '')
+  .replace(/^git\+/, '')
+  .replace(/\.git$/, '');
+if (!repoUrl.startsWith('http')) fail('could not derive an https repository URL from package.json');
+
+log(`preparing release ${tag} for ${name}`);
+
+// 1. Clean tree on the default branch.
+const branch = run('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+if (branch !== DEFAULT_BRANCH) fail(`must release from "${DEFAULT_BRANCH}", currently on "${branch}"`);
+if (run('git', ['status', '--porcelain'])) fail('working tree is not clean; commit or stash first');
+
+const sha = run('git', ['rev-parse', 'HEAD']);
+log(`commit: ${sha}`);
+
+// 2. Publish-first: the version must already exist on npm.
+const npmVersion = tryRun('npm', ['view', `${name}@${version}`, 'version']);
+if (!npmVersion.ok || npmVersion.out !== version) {
+  fail(`${name}@${version} is not on the npm registry yet. Run "npm publish" first.`);
+}
+log(`confirmed ${name}@${version} is published`);
+
+// 3. The release must not already exist.
+if (tryRun('gh', ['release', 'view', tag]).ok) fail(`release ${tag} already exists`);
+
+// Notes: the CHANGELOG section for this version + a compare link.
+const changelog = readFileSync('CHANGELOG.md', 'utf8');
+const startIdx = changelog.indexOf(`## [${version}]`);
+if (startIdx === -1) fail(`no CHANGELOG.md section found for [${version}]`);
+const bodyStart = changelog.indexOf('\n', startIdx) + 1;
+const rest = changelog.slice(bodyStart);
+// The section ends at the next version heading or the trailing link-reference
+// block (`[x.y.z]: url`), whichever comes first. The link-reference bound
+// matters for the oldest entry, which has no following heading.
+const bounds = [rest.search(/\n## \[/), rest.search(/\n\[[^\]]+\]:\s/)].filter((i) => i !== -1);
+const section = rest.slice(0, bounds.length ? Math.min(...bounds) : rest.length).trim();
+
+const versions = [...changelog.matchAll(/^## \[(\d+\.\d+\.\d+)\]/gm)].map((m) => m[1]);
+const prev = versions[versions.indexOf(version) + 1];
+const compareUrl = prev
+  ? `${repoUrl}/compare/v${prev}...${tag}`
+  : `${repoUrl}/releases/tag/${tag}`;
+const notes = `${section}\n\n**Full changelog:** ${compareUrl}`;
+
+if (DRY_RUN) {
+  log('dry run: no release will be created');
+  log(`tag:     ${tag}`);
+  log(`target:  ${sha}`);
+  log(`asset:   lib.zip (from lib/)`);
+  log('notes:');
+  console.log(notes);
+  process.exit(0);
+}
+
+// 4. Build and zip the asset.
+log('building lib/');
+run('yarn', ['build']);
+rmSync('lib.zip', { force: true });
+log('zipping lib.zip');
+run('zip', ['-r', 'lib.zip', 'lib/']);
+
+// 5. Create the release (creates the tag) and attach the asset.
+try {
+  log(`creating release ${tag}`);
+  const url = run('gh', [
+    'release',
+    'create',
+    tag,
+    'lib.zip',
+    '--target',
+    sha,
+    '--title',
+    tag,
+    '--notes',
+    notes,
+  ]);
+  log(`released: ${url}`);
+} finally {
+  rmSync('lib.zip', { force: true });
+}


### PR DESCRIPTION
## What Changed

Borrows the development and release workflow from the sibling `logical-compiler` repo and finishes rbactl's move to GitHub as the canonical remote.

- **CI** — GitHub Actions (`.github/workflows/ci.yml`): the library is linted, built, and tested across a Node 18/20/22 matrix (gating). The MongoDB and PostgreSQL example apps run against service containers but are non-gating for now (see below).
- **Changelog** — `CHANGELOG.md` following Keep a Changelog + SemVer, seeded with `[0.1.0]` and an `[Unreleased]` section.
- **Release** — `scripts/release.mjs` + `release` script: publish-first GitHub release for the `package.json` version, with notes pulled from the changelog and the built `lib/` attached as `lib.zip`.
- **PR template** — `.github/PULL_REQUEST_TEMPLATE.md`.
- **Publish hygiene** — `types` and `files` fields, author email, and GitHub repository URLs in `package.json`.
- **README** — GitHub Actions build badge, dropped the GitLab coverage badge, repo links lead with GitHub (GitLab kept as a mirror).

## Why

Consolidate tooling on GitHub and make publishing repeatable instead of manual.

## How to Test

1. `yarn install && yarn build && yarn lint && yarn test` — library pipeline is green (74 tests).
2. `node scripts/release.mjs --dry-run` — prints the plan and halts on its branch/publish guards.
3. CI runs automatically on this PR.

## Notes

- The example app jobs are `continue-on-error` because they pin 2019-era native deps (`bcrypt@3` via node-pre-gyp, mongoose@5, sequelize@5) that don't build on current Node. Drop `continue-on-error` once those deps are modernized. Tracked alongside #5.
- `eslint` is scoped to the library for the same reason (`examples` added to `.eslintignore`).