### PR TITLE
Adopt logical-compiler as the policy rule evaluator (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pull request template (`.github/PULL_REQUEST_TEMPLATE.md`).
 - Explicit `types` and `files` fields in `package.json` so the published
   package ships only `lib/` and `index.js`.
+- `$not` and `$nor` logical operators in policy rules, and implicit AND across
+  the multiple keys of a policy object.
 
 ### Changed
 
+- Policy rule evaluation is now delegated to the
+  [`logical-compiler`](https://github.com/mutaimwiti/logical-compiler) library.
+  Promise-returning callbacks are now supported at any nesting depth, including
+  inside `$and`/`$or`/`$not`/`$nor` — previously a promise callback nested in an
+  operator threw `Unexpected nested promise callback`. A callback resolving to a
+  non-boolean value now throws a `LogicalCompilerError` (was a generic `[rbactl]`
+  error). `authorize()` still returns a `boolean` for fully synchronous policies
+  and a `Promise<boolean>` when any rule is asynchronous.
 - Reworked the MongoDB and PostgreSQL example test suites: database
   connections are created and closed separately, a global setup clears the
   database before runs, and shared test utilities are grouped on their own.
+
+### Fixed
+
+- A policy object with multiple keys is now AND-ed together instead of silently
+  evaluating only the first key.
 
 ## [0.1.0] - 2019-08-13
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -426,12 +426,13 @@ boolean values to avoid the ambiguity of relying on truthiness. Examples:
 
 ##### `Logical rules`
 
-Logical rules allow for combination of other rules using logical operators `AND` and `OR`. The library requires AND to
-be represented using `$and` and OR to be represented using `$or`. The value of any logical operator should be an
-`array`. At this point things get a little more complicated and I don't have many actual examples to demonstrate the
-use of logical rules. Because of that, I will use dummy entities and actions. Note that these logical rules are only
-available to ensure that even complex rules can be defined without breaking a sweat. `someCheck` defined below is a
-prerequisite callback for the examples to avoid repeating its definition over and over again.
+Logical rules allow for combination of other rules using logical operators. The library supports `$and`, `$or`, `$nor`
+(whose values are an `array` of rules) and `$not` (whose value is a single rule). `$not` negates a rule and `$nor`
+negates an `$or`. When an object rule has multiple keys they are implicitly AND-ed together. At this point things get a
+little more complicated and I don't have many actual examples to demonstrate the use of logical rules. Because of that,
+I will use dummy entities and actions. Note that these logical rules are only available to ensure that even complex
+rules can be defined without breaking a sweat. `someCheck` defined below is a prerequisite callback for the examples to
+avoid repeating its definition over and over again.
 
 ```javascript
 const someCheck = () => {
@@ -592,11 +593,11 @@ This rule combines OR and AND rules.
 
 ##### IMPORTANT NOTES ON POLICY RULES
 
-1. An asynchronous call can be made inside a callback rule function. Currently, the library does not support promise
-   returning callbacks on nested rules. If one is found an exception is thrown. Promise returning callback rules are
-   only allowed ALONE. The clean workaround is to resolve values resulting from asynchronous calls before triggering
-   the authorization middleware. In the callback example above (`req callback`), that's exactly the case - the rule
-   expects the article in question to have been queried and resolved by a previous middleware.
+1. An asynchronous call can be made inside a callback rule function. Promise returning callbacks are supported at any
+   nesting depth, including inside `$and`, `$or`, `$not` and `$nor`. When any rule resolves asynchronously, `authorize()`
+   returns a promise, so be sure to `await` it (see the notes on authorization below). Resolving values from
+   asynchronous calls in a preceding middleware - as in the `req callback` example above - remains the cleanest pattern
+   and keeps the authorization check synchronous.
 
 2. Callback rules must explicitly return boolean values to avoid the ambiguity of relying on truthiness. Relying on
    truthiness would pose a serious security loophole. This is because the callback might accidentally resolve to true
@@ -767,8 +768,8 @@ const can = (action, entity) => {
       // authorization was successful - invoke the next middleware
       return next();
     } catch (e) {
-      // three exceptions can be thrown by the authorize function:
-      // missing policy, missing policy action or unexpected nested promise callback
+      // exceptions thrown by the authorize function include: missing policy,
+      // missing policy action, or a callback resolving to a non-boolean value
       return res.status(500).json({
         message: 'Sorry :( Something bad happened.',
       });

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -434,6 +434,11 @@ I will use dummy entities and actions. Note that these logical rules are only av
 rules can be defined without breaking a sweat. `someCheck` defined below is a prerequisite callback for the examples to
 avoid repeating its definition over and over again.
 
+> Logical rules are powered by [logical-compiler](https://github.com/mutaimwiti/logical-compiler). It evaluates the
+> boolean expression with proper short-circuiting (an `$and` stops at the first `false`, an `$or` at the first `true`),
+> supports both synchronous and promise-returning callbacks at **any** nesting depth, and treats the multiple keys of a
+> rule object as an implicit `AND`. This is what lets you compose `$and`, `$or`, `$not` and `$nor` freely.
+
 ```javascript
 const someCheck = () => {
   return shouldBeAllowed();
@@ -590,6 +595,62 @@ This rule combines OR and AND rules.
   ```
 
   > Rules can be nested in any fashion to achieve the desired logical check.
+
+###### `NOT rule`
+
+This rule negates the result of the single rule provided to it.
+
+- Example
+
+  ```
+  {
+    foo: {
+      archive: { $not: { any: ['foo.x', 'foo.y'] } },
+    },
+  }
+  ```
+
+  > This rule means that `foo` can be archived only if the user has NEITHER `foo.x` NOR `foo.y` permission.
+
+###### `NOR rule`
+
+This rule performs a logical NOR on the provided rules - it is the negation of `$or`. It passes only when none of the
+provided rules pass.
+
+- Example
+
+  ```
+  {
+    foo: {
+      lock: { $nor: ['foo.x', someCheck] },
+    },
+  }
+  ```
+
+  > This rule means that `foo` can be locked only if the user does NOT have `foo.x` permission AND `someCheck` returns
+  > `false`.
+
+###### `Implicit AND`
+
+When a rule object has more than one key, the keys are implicitly AND-ed together. This holds at any nesting depth, so
+it is rarely needed at the top level but is handy for combining an operator with a permission rule without an extra
+wrapping `$and`.
+
+- Example
+
+  ```
+  {
+    foo: {
+      activate: {
+        $or: ['foo.x', 'foo.y'],
+        all: ['foo.m', 'foo.n'],
+      },
+    },
+  }
+  ```
+
+  > This rule means that for `foo` to be activated, the user must have either `foo.x` or `foo.y`, AND must have both
+  > `foo.m` and `foo.n`. It is equivalent to wrapping both keys in an `$and`.
 
 ##### IMPORTANT NOTES ON POLICY RULES
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",
+    "logical-compiler": "^0.4.0",
     "require-all": "^3.0.0"
   }
 }

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -1,61 +1,86 @@
+import compile from 'logical-compiler';
 import { hasAllPermissions, hasAnyPermission } from './permissions';
 import { createException } from './utils';
 
+// Operators whose value is a list of sub-policies.
+const LIST_OPERATORS = ['$and', '$or', '$nor'];
+
 /**
- * Credit - https://stackoverflow.com/questions/55240828
+ * Adapt an rbactl policy into a logical-compiler expression.
+ *
+ * rbactl's policy DSL differs from logical-compiler's expression grammar in two
+ * places that need wrapping into the compiler's zero-argument callbacks:
+ *
+ * - a bare string is a permission check (the user must hold that permission);
+ * - a callback is invoked with the request object.
+ *
+ * Everything else - the boolean logic of $and/$or/$not/$nor, short-circuiting,
+ * synchronous vs. promise-returning rules (at any nesting depth) and implicit
+ * AND across the keys of an object - is handled by logical-compiler. The any
+ * and all rules are passed through untouched and routed to the compiler's
+ * `fns` (see authorizeActionAgainstPolicy).
+ *
+ * @param policy
+ * @param userPermissions
+ * @param req
+ * @returns {*}
+ */
+const toExpression = (policy, userPermissions, req) => {
+  if (typeof policy === 'string') {
+    return () => hasAllPermissions(userPermissions, [policy]);
+  }
+
+  if (typeof policy === 'function') {
+    return () => policy(req);
+  }
+
+  if (Array.isArray(policy)) {
+    return policy.map((sub) => toExpression(sub, userPermissions, req));
+  }
+
+  if (policy && typeof policy === 'object') {
+    return Object.fromEntries(
+      Object.entries(policy).map(([key, value]) => {
+        if (LIST_OPERATORS.includes(key)) {
+          return [
+            key,
+            value.map((sub) => toExpression(sub, userPermissions, req)),
+          ];
+        }
+        if (key === '$not') {
+          return [key, toExpression(value, userPermissions, req)];
+        }
+        // any / all (and any unrecognized key) are left for logical-compiler
+        // to route to `fns` or to reject with a descriptive error.
+        return [key, value];
+      }),
+    );
+  }
+
+  return policy;
+};
+
+/**
+ * Authorize an action policy against the user permissions. The boolean rule
+ * evaluation is delegated to logical-compiler; the any and all rules are
+ * supplied as compiler functions bound to the user's permissions.
  *
  * @param userPermissions
  * @param actionPolicy
  * @param req
- * @returns {*|*|*}
+ * @returns {boolean|Promise<boolean>}
  */
 export const authorizeActionAgainstPolicy = (
   userPermissions,
   actionPolicy,
   req,
 ) => {
-  let callCount = 0;
-
-  const authorize = (policy) => {
-    callCount += 1;
-    const operators = { $or: 'some', $and: 'every' };
-    const fns = {
-      any: (permissions) => hasAnyPermission(userPermissions, permissions),
-      all: (permissions) => hasAllPermissions(userPermissions, permissions),
-    };
-
-    if (typeof policy === 'string')
-      return hasAllPermissions(userPermissions, [policy]);
-
-    if (typeof policy === 'function') {
-      const result = policy(req);
-      if (result instanceof Promise) {
-        if (callCount > 1) {
-          throw createException('Unexpected nested promise callback.');
-        }
-      } else {
-        const resultType = typeof result;
-
-        if (resultType !== 'boolean') {
-          throw createException(
-            `Unexpected return type [${resultType}] from a callback.`,
-          );
-        }
-      }
-
-      return result;
-    }
-
-    if (!policy || typeof policy !== 'object') return false;
-
-    const [key, value] = Object.entries(policy)[0];
-
-    if (key in operators) return value[operators[key]](authorize);
-    if (key in fns) return fns[key](value);
-    return false;
+  const fns = {
+    any: (...permissions) => hasAnyPermission(userPermissions, permissions),
+    all: (...permissions) => hasAllPermissions(userPermissions, permissions),
   };
 
-  return authorize(actionPolicy);
+  return compile(toExpression(actionPolicy, userPermissions, req), { fns });
 };
 
 /**
@@ -83,14 +108,7 @@ export const authorize = (
   if (policy) {
     const actionPolicy = policy[action];
     if (actionPolicy) {
-      try {
-        return authorizeActionAgainstPolicy(userPermissions, actionPolicy, req);
-      } catch (e) {
-        // an exception is thrown when:
-        // - a nested promise callback is encountered
-        // - a callback returns a non-boolean value - does not apply to promise callbacks
-        throw e;
-      }
+      return authorizeActionAgainstPolicy(userPermissions, actionPolicy, req);
     }
     throw createException(
       `The [${entity}] policy does not define action [${action}].`,

--- a/test/tests/authorize/authorize/basic/callback.spec.js
+++ b/test/tests/authorize/authorize/basic/callback.spec.js
@@ -1,5 +1,4 @@
 import authorize from '../../../../utils/authorize';
-import { createException } from '../../../../../src/utils';
 
 describe('authorize.js - callback', () => {
   it('should check for authorization correctly - success', () => {
@@ -32,7 +31,7 @@ describe('authorize.js - callback', () => {
 
   it('should throw exception when a callback returns a non-boolean value', () => {
     expect(() => authorize('renew', 'foo', [])).toThrow(
-      createException(`Unexpected return type [string] from a callback.`),
+      'Unexpected return type [string] from a callback',
     );
   });
 });

--- a/test/tests/authorize/authorize/logical/case11.spec.js
+++ b/test/tests/authorize/authorize/logical/case11.spec.js
@@ -31,5 +31,13 @@ describe('authorize.js - complex - case 11', () => {
       expect(authorize('combo', 'bar', ['bar.m'])).toEqual(false);
       expect(authorize('combo', 'bar', [])).toEqual(false);
     });
+
+    // bar.merge = { $or: ['bar.a', 'bar.b'], all: ['bar.m'] }
+    it('AND-s an operator key with a rule key', () => {
+      expect(authorize('merge', 'bar', ['bar.a', 'bar.m'])).toEqual(true);
+      expect(authorize('merge', 'bar', ['bar.b', 'bar.m'])).toEqual(true);
+      expect(authorize('merge', 'bar', ['bar.a'])).toEqual(false);
+      expect(authorize('merge', 'bar', ['bar.m'])).toEqual(false);
+    });
   });
 });

--- a/test/tests/authorize/authorize/logical/case11.spec.js
+++ b/test/tests/authorize/authorize/logical/case11.spec.js
@@ -1,0 +1,35 @@
+import authorize from '../../../../utils/authorize';
+
+// Capabilities gained by delegating evaluation to logical-compiler:
+// $not, $nor, and implicit AND across multiple keys of a policy object.
+describe('authorize.js - complex - case 11', () => {
+  describe('$not', () => {
+    // bar.block = { $not: { any: ['bar.x', 'bar.y'] } }
+    it('authorizes only when the user lacks the negated permissions', () => {
+      expect(authorize('block', 'bar', [])).toEqual(true);
+      expect(authorize('block', 'bar', ['bar.z'])).toEqual(true);
+      expect(authorize('block', 'bar', ['bar.x'])).toEqual(false);
+      expect(authorize('block', 'bar', ['bar.x', 'bar.y'])).toEqual(false);
+    });
+  });
+
+  describe('$nor', () => {
+    // bar.gate = { $nor: ['bar.a', 'bar.b'] }
+    it('authorizes only when the user has none of the permissions', () => {
+      expect(authorize('gate', 'bar', [])).toEqual(true);
+      expect(authorize('gate', 'bar', ['bar.c'])).toEqual(true);
+      expect(authorize('gate', 'bar', ['bar.a'])).toEqual(false);
+      expect(authorize('gate', 'bar', ['bar.b'])).toEqual(false);
+    });
+  });
+
+  describe('implicit AND across multiple keys', () => {
+    // bar.combo = { any: ['bar.a'], all: ['bar.m'] }
+    it('requires every key to pass', () => {
+      expect(authorize('combo', 'bar', ['bar.a', 'bar.m'])).toEqual(true);
+      expect(authorize('combo', 'bar', ['bar.a'])).toEqual(false);
+      expect(authorize('combo', 'bar', ['bar.m'])).toEqual(false);
+      expect(authorize('combo', 'bar', [])).toEqual(false);
+    });
+  });
+});

--- a/test/tests/authorize/authorize/logical/case6.spec.js
+++ b/test/tests/authorize/authorize/logical/case6.spec.js
@@ -1,10 +1,15 @@
 import authorize from '../../../../utils/authorize';
-import { createException } from '../../../../../src/utils';
 
+// bar.share = { $and: [{ any: ['bar.g'] }, async () => true] }
+// A promise-returning callback nested inside an operator. This used to throw
+// 'Unexpected nested promise callback'; it is now evaluated correctly.
 describe('authorize.js - complex - case 6', () => {
-  it('should throw exception when nested promise callback id found', async () => {
-    expect(() => authorize('share', 'bar', ['bar.g'])).toThrow(
-      createException('Unexpected nested promise callback.'),
-    );
+  it('should resolve a nested promise callback rule - success', async () => {
+    expect(await authorize('share', 'bar', ['bar.g'])).toEqual(true);
+  });
+
+  it('should resolve a nested promise callback rule - failure', async () => {
+    // without bar.g the $and short-circuits to false before the async branch
+    expect(await authorize('share', 'bar', [])).toEqual(false);
   });
 });

--- a/test/tests/authorize/can/can.spec.js
+++ b/test/tests/authorize/can/can.spec.js
@@ -80,6 +80,14 @@ describe('authorize.js - can()', () => {
         message: 'You are not authorized to perform this action.',
       });
     });
+
+    it('should trigger next() for a resolved nested promise rule', async () => {
+      // bar.share nests a promise callback inside $and; the mock user has
+      // 'bar.g', so it resolves to authorized.
+      await express.callMiddleware(can.fn('share', 'bar'));
+
+      expect(express.next).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('handling exceptions', () => {
@@ -118,18 +126,6 @@ describe('authorize.js - can()', () => {
           createException(
             'The [blog] policy does not define action [publish].',
           ),
-        );
-      });
-
-      it('should trigger authorizationExceptionHandler() for unexpected nested promise callbacks', async () => {
-        await express.callMiddleware(can.fn('share', 'bar'));
-
-        expect(can.authorizationExceptionHandler).toHaveBeenCalledTimes(1);
-        expect(can.authorizationExceptionHandler).toHaveBeenCalledWith(
-          express.request,
-          express.response,
-          express.next,
-          createException('Unexpected nested promise callback.'),
         );
       });
     });

--- a/test/utils/policies/samplePolicies/bar.js
+++ b/test/utils/policies/samplePolicies/bar.js
@@ -46,7 +46,7 @@ export default {
       { any: ['bar.x', 'bar.y'] },
     ],
   },
-  // a nested promise callback - not supported
+  // a promise callback nested inside an operator
   share: {
     $and: [{ any: ['bar.g'] }, async () => true],
   },
@@ -61,5 +61,18 @@ export default {
   },
   restart: {
     $and: ['bar.g', 'bar.h', { any: ['bar.j', 'bar.k', 'bar.l'] }],
+  },
+  // $not - authorized only when the user lacks any of the listed permissions
+  block: {
+    $not: { any: ['bar.x', 'bar.y'] },
+  },
+  // $nor - authorized only when the user has none of the listed permissions
+  gate: {
+    $nor: ['bar.a', 'bar.b'],
+  },
+  // multiple keys are implicitly AND-ed: any(bar.a) AND all(bar.m)
+  combo: {
+    any: ['bar.a'],
+    all: ['bar.m'],
   },
 };

--- a/test/utils/policies/samplePolicies/bar.js
+++ b/test/utils/policies/samplePolicies/bar.js
@@ -75,4 +75,9 @@ export default {
     any: ['bar.a'],
     all: ['bar.m'],
   },
+  // implicit AND mixing an operator and a rule: (bar.a OR bar.b) AND all(bar.m)
+  merge: {
+    $or: ['bar.a', 'bar.b'],
+    all: ['bar.m'],
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,6 +643,11 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
+"@babel/runtime@^7.12.5":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/runtime@^7.4.4":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.1.tgz#b223497bbfbcbbb38116673904debc71470ca528"
@@ -3154,6 +3159,13 @@ lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+logical-compiler@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/logical-compiler/-/logical-compiler-0.4.0.tgz#738c47ed3904813c8c7cfca8bd8c1e08bb9680c8"
+  integrity sha512-D+X6NDQXRYRk+Gshw2vH+vX/pwr7ZS7KnfHUjrds6bSFItDTxZRffDcKOcyTNJ//461244jnaj0v2Desrj+Kbw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 loose-envify@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
Closes #5.

## What Changed

Replaces the bespoke recursive evaluator in `authorizeActionAgainstPolicy` (`src/authorize.js`) with the [`logical-compiler`](https://github.com/mutaimwiti/logical-compiler) library. rbactl's policy DSL is adapted into a logical-compiler expression with a thin walk:

- bare string permissions → zero-arg callbacks that check the permission;
- `(req) => ...` callbacks → zero-arg callbacks closing over `req`;
- `any` / `all` rules → compiler `fns` bound to the user's permissions.

All boolean logic — short-circuiting, sync/async evaluation, nesting and implicit multi-key AND — is delegated to logical-compiler.

## Why

The old evaluator had two real limitations:

1. **Nested promise callbacks were unsupported** — `$or`/`$and` used synchronous `.some`/`.every`, so a promise-returning callback nested in an operator could not be awaited; the code guarded this by throwing `Unexpected nested promise callback`.
2. **Only the first key of an object policy was read**, so multi-key policies silently ignored the rest.

## Fixes & additions

- Nested promise callbacks now evaluate correctly at any depth.
- Multi-key policy objects are now AND-ed together (implicit AND).
- `$not` and `$nor` operators are now supported.
- A callback resolving to a non-boolean value now throws a typed `LogicalCompilerError`.

## How to Test

1. `yarn install && yarn build && yarn lint && yarn test` — 79 tests pass.
2. New/updated tests: `case6` (nested promise now resolves), `case11` ($not/$nor/implicit AND), `callback` (typed error), `can` (nested-promise success at the middleware level).

## Docs

`DOCUMENTATION.md` updated: removed the now-false "nested promises unsupported" caveat, documented `$not`/`$nor`/implicit AND, and added a note on the logical-compiler benefits. `CHANGELOG.md` updated under Unreleased.

## Notes

The `example-*` CI jobs fail on the unrelated `bcrypt@3` dep rot; they are non-gating (`continue-on-error`), so this PR remains mergeable. Tracked separately.