### PR TITLE
Accept plain permission arrays in permission functions (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   package ships only `lib/` and `index.js`.
 - `$not` and `$nor` logical operators in policy rules, and implicit AND across
   the multiple keys of a policy object.
+- `validatePermissions()` and `getAllPermissionsFor()` now accept the system
+  permissions as a plain array of permission strings, in addition to the
+  permissions map.
 
 ### Changed
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -238,7 +238,8 @@ Sample output:
 This function checks a list of permissions against the system permissions. It returns an object with two values:
 `valid (boolean)` indicating whether the permissions are valid and `invalids (list)` with any invalid permissions
 found. It expects two parameters; `systemPermissions` and `permissions`. `systemPermissions` is the list all of system
-permissions. `permissions` is the list of permissions to validate. Example:
+permissions - either the permissions map (e.g. `parsePermissions(permissions).$all`) or a plain array of permission
+strings. `permissions` is the list of permissions to validate. Example:
 
 ```javascript
 const systemPermisions = parsePermissions(permissions).$all;
@@ -261,8 +262,8 @@ Output:
 ##### `getAllPermissionsFor()`
 
 This function returns all the permissions for a given system entity. It expects two parameters; `systemPermissions`
-and `entity`. `systemPermissions` is the the list all system permissions. `entity` is very much self explanatory.
-Example:
+and `entity`. `systemPermissions` is the the list all system permissions - either the permissions map or a plain array
+of permission strings. `entity` is very much self explanatory. Example:
 
 ```javascript
 const systemPermisions = loadPermissions(`${__dirname}/permissions`).$all;

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -1,6 +1,19 @@
 import requireAll from 'require-all';
 
 /**
+ * System permissions may be supplied either as the permissions map produced by
+ * loadPermissions()/parsePermissions() (an object keyed by permission) or as a
+ * plain array of permission strings. Normalize either form to a list of keys.
+ *
+ * @param systemPermissions
+ * @returns {string[]}
+ */
+const toPermissionKeys = (systemPermissions) =>
+  Array.isArray(systemPermissions)
+    ? systemPermissions
+    : Object.keys(systemPermissions);
+
+/**
  * Generate the full group permission string for the passed permission i.e if
  * the permission is [user.create] it returns [user.*] which is the full
  * permission for the user permission group. If the permission is
@@ -121,7 +134,8 @@ export const parsePermissions = (permissionsObj) => {
 /**
  * Checks a list of permissions against the system permissions. It returns an
  * object with two values: valid (boolean) indicating whether its valid and
- * invalids (list) with any invalid permission that may be found.
+ * invalids (list) with any invalid permission that may be found. The system
+ * permissions may be the permissions map or a plain array of permissions.
  *
  * @param systemPermissions
  * @param permissions
@@ -130,7 +144,7 @@ export const parsePermissions = (permissionsObj) => {
 export const validatePermissions = (systemPermissions, permissions) => {
   let isValid = true;
   const invalids = [];
-  const systemPermissionKeys = Object.keys(systemPermissions);
+  const systemPermissionKeys = toPermissionKeys(systemPermissions);
   permissions.forEach((permission) => {
     if (systemPermissionKeys.indexOf(permission) < 0) {
       isValid = false;
@@ -160,14 +174,15 @@ export const getPermissionsMap = (systemPermissions, permissions) => {
 
 /**
  * Get all the permissions for an entity. For example passing 'x' will
- * return [ 'x.*', 'x.view', 'c.create', ..., ].
+ * return [ 'x.*', 'x.view', 'c.create', ..., ]. The system permissions may be
+ * the permissions map or a plain array of permissions.
  *
  * @param systemPermissions
  * @param entity
  * @returns {string[]}
  */
 export const getAllPermissionsFor = (systemPermissions, entity) => {
-  return Object.keys(systemPermissions).filter((permission) =>
+  return toPermissionKeys(systemPermissions).filter((permission) =>
     permission.startsWith(entity),
   );
 };

--- a/test/tests/permissions/allPermissionsFor.spec.js
+++ b/test/tests/permissions/allPermissionsFor.spec.js
@@ -22,5 +22,19 @@ describe('permissions.js', () => {
     it('should give an empty list when permission group does not exist', () => {
       expect(getAllPermissionsFor(systemPermissions.$all, 'job')).toEqual([]);
     });
+
+    it('should accept a plain array of system permissions', () => {
+      const allPermissions = [
+        'article.list',
+        'article.create',
+        'item.list',
+        'item.create',
+      ];
+
+      expect(getAllPermissionsFor(allPermissions, 'article')).toEqual([
+        'article.list',
+        'article.create',
+      ]);
+    });
   });
 });

--- a/test/tests/permissions/validatePermissions.spec.js
+++ b/test/tests/permissions/validatePermissions.spec.js
@@ -30,5 +30,17 @@ describe('permissions.js', () => {
         invalids: ['article.create'],
       });
     });
+
+    it('should accept a plain array of system permissions', () => {
+      const allowed = ['article.list', 'article.get', 'article.create'];
+
+      expect(
+        validatePermissions(allowed, ['article.list', 'article.get']),
+      ).toEqual({ isValid: true, invalids: [] });
+
+      expect(
+        validatePermissions(allowed, ['article.list', 'article.remove']),
+      ).toEqual({ isValid: false, invalids: ['article.remove'] });
+    });
   });
 });


### PR DESCRIPTION
Closes #3.

## What Changed

`validatePermissions()` and `getAllPermissionsFor()` previously required `systemPermissions` to be the permissions-map object produced by `loadPermissions()`/`parsePermissions()`. They now also accept a plain array of permission strings, e.g. `['article.list', 'article.get']`, via a shared `toPermissionKeys` helper that normalizes either form.

## Why

Makes these helpers more flexible for callers that already have a flat list of permissions and don't need the description map.

## How to Test

1. `yarn install && yarn build && yarn lint && yarn test` — 81 tests pass.
2. New cases in `validatePermissions.spec.js` and `allPermissionsFor.spec.js` exercise the plain-array form.

## Docs

`DOCUMENTATION.md` updated for both functions; `CHANGELOG.md` updated under Unreleased.

## Notes

Independent of the evaluator work; the `example-*` CI jobs fail on the unrelated `bcrypt@3` dep rot (non-gating, still mergeable).