### PR TITLE
Add $grant and $deny entity override rules (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `validatePermissions()` and `getAllPermissionsFor()` now accept the system
   permissions as a plain array of permission strings, in addition to the
   permissions map.
-- `$grant` entity policy rule: when it passes it authorizes any defined action
-  on the entity regardless of the per-action policy (e.g. for admin access).
+- `$grant` and `$deny` entity policy rules, evaluated before the action policy.
+  `$grant` authorizes any defined action when it passes (e.g. admin access);
+  `$deny` denies any action when it passes and takes precedence over both
+  `$grant` and the per-action policy (e.g. suspended users). Authorization is
+  `NOT $deny AND ($grant OR action)`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `validatePermissions()` and `getAllPermissionsFor()` now accept the system
   permissions as a plain array of permission strings, in addition to the
   permissions map.
+- `$grant` entity policy rule: when it passes it authorizes any defined action
+  on the entity regardless of the per-action policy (e.g. for admin access).
 
 ### Changed
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -43,6 +43,8 @@
 
      - [Important notes](#important-notes-on-policy-rules)
 
+   - [The $grant rule](#the-grant-rule) - authorize any action on an entity when a grant rule passes.
+
 6. [Authorization](#authorization)
 
    - [Functions](#authorization-functions)
@@ -675,6 +677,31 @@ wrapping `$and`.
    specified. This is because they're automatically checked. For example, if it is specified that a user requires
    `blog.delete` permission to delete a blog, the library will automatically determine that a user with `blog.*`
    permission can delete a blog.
+
+#### The `$grant` rule
+
+An entity policy may define a `$grant` rule. It is evaluated before the action policy and, if it passes, authorizes
+the action regardless of what the action policy says (it is effectively OR-ed with every action). This is the clean
+way to grant a privileged user - for example an admin - access to every action on the entity without repeating the
+check on each action. The `$grant` value is an ordinary rule, so it may be a permission string, an `any`/`all` rule, a
+callback or a logical combination. Note that `$grant` can only grant access; it never denies an action that the
+per-action policy would allow.
+
+```javascript
+{
+  article: {
+    // a user with full article access may perform any article action
+    $grant: 'article.*',
+    create: 'article.create',
+    update: { $and: ['article.update', isOwner] },
+    remove: 'article.remove',
+  },
+}
+```
+
+> With the policy above, a user holding `article.*` can `create`, `update` or `remove` an article even though they are
+> not the owner. Any other user is still subject to the per-action policy. The action must still be defined on the
+> policy - `$grant` does not grant access to actions the entity does not declare.
 
 ### Authorization
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -43,7 +43,8 @@
 
      - [Important notes](#important-notes-on-policy-rules)
 
-   - [The $grant rule](#the-grant-rule) - authorize any action on an entity when a grant rule passes.
+   - [The $grant and $deny rules](#the-grant-and-deny-rules) - authorize or deny any action on an entity before the
+     per-action policy is consulted.
 
 6. [Authorization](#authorization)
 
@@ -678,20 +679,27 @@ wrapping `$and`.
    `blog.delete` permission to delete a blog, the library will automatically determine that a user with `blog.*`
    permission can delete a blog.
 
-#### The `$grant` rule
+#### The `$grant` and `$deny` rules
 
-An entity policy may define a `$grant` rule. It is evaluated before the action policy and, if it passes, authorizes
-the action regardless of what the action policy says (it is effectively OR-ed with every action). This is the clean
-way to grant a privileged user - for example an admin - access to every action on the entity without repeating the
-check on each action. The `$grant` value is an ordinary rule, so it may be a permission string, an `any`/`all` rule, a
-callback or a logical combination. Note that `$grant` can only grant access; it never denies an action that the
-per-action policy would allow.
+An entity policy may define two optional rules that are evaluated before the action policy:
+
+- `$grant` - if it passes, the action is authorized regardless of what the action policy says. This is the clean way
+  to grant a privileged user - for example an admin - access to every action on the entity without repeating the
+  check on each action.
+- `$deny` - if it passes, the action is denied regardless of `$grant` or the action policy. This is the clean way to
+  block a user - for example one who is suspended - from every action on the entity.
+
+`$deny` takes precedence over `$grant`, which takes precedence over the action policy. In other words authorization is
+`NOT $deny AND ($grant OR action)`. Each is an ordinary rule (a permission string, an `any`/`all` rule, a callback or
+a logical combination) and each is optional.
 
 ```javascript
 {
   article: {
-    // a user with full article access may perform any article action
+    // a user with full article access may perform any article action ...
     $grant: 'article.*',
+    // ... unless they are suspended, in which case they may perform none
+    $deny: (req) => req.user.isSuspended,
     create: 'article.create',
     update: { $and: ['article.update', isOwner] },
     remove: 'article.remove',
@@ -699,9 +707,9 @@ per-action policy would allow.
 }
 ```
 
-> With the policy above, a user holding `article.*` can `create`, `update` or `remove` an article even though they are
-> not the owner. Any other user is still subject to the per-action policy. The action must still be defined on the
-> policy - `$grant` does not grant access to actions the entity does not declare.
+> With the policy above, a suspended user is denied every action even if they hold `article.*`; a non-suspended
+> `article.*` holder may perform any action; everyone else is subject to the per-action policy. The action must still
+> be defined on the policy - these rules do not apply to actions the entity does not declare.
 
 ### Authorization
 

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -89,6 +89,11 @@ export const authorizeActionAgainstPolicy = (
  * the req object. This allows the user to authorize based on req
  * parameters.
  *
+ * An entity policy may define a `$grant` rule. It is evaluated before the
+ * action policy and, if it passes, authorizes the action regardless of the
+ * action policy - useful for granting a privileged user (e.g. an admin) access
+ * to every action on the entity. The action must still be defined.
+ *
  * @param action
  * @param entity
  * @param userPermissions
@@ -108,7 +113,18 @@ export const authorize = (
   if (policy) {
     const actionPolicy = policy[action];
     if (actionPolicy) {
-      return authorizeActionAgainstPolicy(userPermissions, actionPolicy, req);
+      // `$grant` short-circuits to authorized when it passes; otherwise the
+      // action policy decides. Expressed as `$grant OR action` so the compiler
+      // handles the short-circuit and any async rules.
+      const effectivePolicy =
+        policy.$grant !== undefined
+          ? { $or: [policy.$grant, actionPolicy] }
+          : actionPolicy;
+      return authorizeActionAgainstPolicy(
+        userPermissions,
+        effectivePolicy,
+        req,
+      );
     }
     throw createException(
       `The [${entity}] policy does not define action [${action}].`,

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -47,9 +47,11 @@ const toExpression = (policy, userPermissions, req) => {
             value.map((sub) => toExpression(sub, userPermissions, req)),
           ];
         }
+
         if (key === '$not') {
           return [key, toExpression(value, userPermissions, req)];
         }
+
         // any / all (and any unrecognized key) are left for logical-compiler
         // to route to `fns` or to reject with a descriptive error.
         return [key, value];
@@ -126,22 +128,27 @@ export const authorize = (
       // defined. The compiler handles short-circuiting (so `$deny` is checked
       // first and can deny without evaluating the rest) and any async rules.
       let effectivePolicy = actionPolicy;
+
       if (policy.$grant !== undefined) {
         effectivePolicy = { $or: [policy.$grant, effectivePolicy] };
       }
+
       if (policy.$deny !== undefined) {
         effectivePolicy = { $and: [{ $not: policy.$deny }, effectivePolicy] };
       }
+
       return authorizeActionAgainstPolicy(
         userPermissions,
         effectivePolicy,
         req,
       );
     }
+
     throw createException(
       `The [${entity}] policy does not define action [${action}].`,
     );
   }
+
   throw createException(`The [${entity}] policy is not defined.`);
 };
 

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -89,10 +89,18 @@ export const authorizeActionAgainstPolicy = (
  * the req object. This allows the user to authorize based on req
  * parameters.
  *
- * An entity policy may define a `$grant` rule. It is evaluated before the
- * action policy and, if it passes, authorizes the action regardless of the
- * action policy - useful for granting a privileged user (e.g. an admin) access
- * to every action on the entity. The action must still be defined.
+ * An entity policy may define two optional override rules that are evaluated
+ * before the action policy:
+ *
+ * - `$grant` - if it passes, the action is authorized regardless of the action
+ *   policy (e.g. an admin who may perform any action).
+ * - `$deny` - if it passes, the action is denied regardless of `$grant` or the
+ *   action policy (e.g. a suspended user who may perform none).
+ *
+ * `$deny` takes precedence over `$grant`, which takes precedence over the
+ * action policy, i.e. authorization is `NOT $deny AND ($grant OR action)`. The
+ * action must still be defined; the overrides do not apply to undeclared
+ * actions.
  *
  * @param action
  * @param entity
@@ -113,13 +121,17 @@ export const authorize = (
   if (policy) {
     const actionPolicy = policy[action];
     if (actionPolicy) {
-      // `$grant` short-circuits to authorized when it passes; otherwise the
-      // action policy decides. Expressed as `$grant OR action` so the compiler
-      // handles the short-circuit and any async rules.
-      const effectivePolicy =
-        policy.$grant !== undefined
-          ? { $or: [policy.$grant, actionPolicy] }
-          : actionPolicy;
+      // Compose the overrides around the action policy as
+      // `NOT $deny AND ($grant OR action)`, omitting whichever hooks are not
+      // defined. The compiler handles short-circuiting (so `$deny` is checked
+      // first and can deny without evaluating the rest) and any async rules.
+      let effectivePolicy = actionPolicy;
+      if (policy.$grant !== undefined) {
+        effectivePolicy = { $or: [policy.$grant, effectivePolicy] };
+      }
+      if (policy.$deny !== undefined) {
+        effectivePolicy = { $and: [{ $not: policy.$deny }, effectivePolicy] };
+      }
       return authorizeActionAgainstPolicy(
         userPermissions,
         effectivePolicy,

--- a/test/tests/authorize/authorize/basic/deny.spec.js
+++ b/test/tests/authorize/authorize/basic/deny.spec.js
@@ -1,0 +1,31 @@
+import authorize from '../../../../utils/authorize';
+
+// The foo policy defines `$deny: (req) => req.suspended === true`. A passing
+// $deny denies the action regardless of $grant or the per-action policy.
+describe('authorize.js - $deny rule', () => {
+  it('denies any action when the $deny rule passes', () => {
+    const req = { suspended: true };
+    // dive would pass for a foo.q holder; $deny overrides it
+    expect(authorize('dive', 'foo', ['foo.q'], req)).toEqual(false);
+    expect(authorize('release', 'foo', ['foo.x'], req)).toEqual(false);
+  });
+
+  it('outranks the $grant rule', () => {
+    // foo.* grants via $grant, but a passing $deny still denies
+    expect(authorize('dive', 'foo', ['foo.*'], { suspended: true })).toEqual(
+      false,
+    );
+    // not suspended → $grant still grants
+    expect(authorize('dive', 'foo', ['foo.*'], { suspended: false })).toEqual(
+      true,
+    );
+  });
+
+  it('does not affect authorization when it fails', () => {
+    // not suspended → the per-action policy applies as normal
+    expect(authorize('dive', 'foo', ['foo.q'], { suspended: false })).toEqual(
+      true,
+    );
+    expect(authorize('dive', 'foo', [], { suspended: false })).toEqual(false);
+  });
+});

--- a/test/tests/authorize/authorize/basic/grant.spec.js
+++ b/test/tests/authorize/authorize/basic/grant.spec.js
@@ -1,0 +1,28 @@
+import authorize from '../../../../utils/authorize';
+
+// The foo policy defines `$grant: 'foo.*'`, granting a user with full foo
+// access every foo action regardless of the per-action policy.
+describe('authorize.js - $grant rule', () => {
+  it('authorizes any defined action when the $grant rule passes', () => {
+    // foo.stop's own policy always denies; foo.load needs foo.m AND foo.n.
+    // The $grant rule overrides both for a holder of foo.*
+    expect(authorize('stop', 'foo', ['foo.*'])).toEqual(true);
+    expect(authorize('load', 'foo', ['foo.*'])).toEqual(true);
+    expect(authorize('dive', 'foo', ['foo.*'])).toEqual(true);
+  });
+
+  it('falls back to the action policy when the $grant rule fails', () => {
+    // without foo.* the per-action policy decides
+    expect(authorize('stop', 'foo', [])).toEqual(false);
+    expect(authorize('load', 'foo', ['foo.m', 'foo.n'])).toEqual(true);
+    expect(authorize('load', 'foo', ['foo.m'])).toEqual(false);
+    expect(authorize('release', 'foo', ['foo.x'])).toEqual(true);
+  });
+
+  it('still requires the action to be defined', () => {
+    // $grant does not grant access to actions the entity does not define
+    expect(() => authorize('lock', 'foo', ['foo.*'])).toThrow(
+      'does not define action [lock]',
+    );
+  });
+});

--- a/test/utils/policies/samplePolicies/foo.js
+++ b/test/utils/policies/samplePolicies/foo.js
@@ -1,4 +1,6 @@
 export default {
+  // grant rule - a user with full foo access may perform any foo action
+  $grant: 'foo.*',
   // basic
   dive: 'foo.q',
   // all

--- a/test/utils/policies/samplePolicies/foo.js
+++ b/test/utils/policies/samplePolicies/foo.js
@@ -1,6 +1,8 @@
 export default {
   // grant rule - a user with full foo access may perform any foo action
   $grant: 'foo.*',
+  // deny rule - a suspended user may perform no foo action (outranks $grant)
+  $deny: (req) => req.suspended === true,
   // basic
   dive: 'foo.q',
   // all


### PR DESCRIPTION
Closes #7.

## What Changed

Adds two optional entity-policy override rules, evaluated before the per-action policy:

- **`$grant`** — if it passes, the action is authorized regardless of the action policy (e.g. an admin who may perform any action).
- **`$deny`** — if it passes, the action is denied regardless of `$grant` or the action policy (e.g. a suspended user who may perform none).

Precedence is `$deny` > `$grant` > action policy, composed as:

```
NOT $deny AND ($grant OR action)
```

built from the `$not`/`$and`/`$or` operators introduced in #5, so `$deny` is checked first and short-circuits to a hard deny, and async rules are handled. Both overrides are optional, accept any rule form (permission string, `any`/`all`, callback, logical combination), and the action must still be declared on the policy.

## Naming — why not `$before`?

The issue proposed a `$before` hook, which traces to Laravel's `Gate::before()`. Laravel's `before()` is **tri-state** (an imperative closure returning `true` = allow, `false` = deny, `null` = defer). rbactl's rules are **declarative booleans**, so a position name like `before` can't encode direction. The faithful translation decomposes the single tri-state hook into two effect-named rules:

| Laravel `before()` | rbactl |
|---|---|
| `return true` (allow) | `$grant` |
| `return false` (deny) | `$deny` |
| `return null` (defer) | neither matches |

This honors the original intent while staying honest about what each rule does (`$grant` can only grant, `$deny` can only deny) — important for an authorization primitive.

## How to Test

1. `yarn install && yarn build && yarn lint && yarn test` — 87 tests pass.
2. New: `basic/grant.spec.js`, `basic/deny.spec.js` (incl. `$deny` outranking `$grant`); the `foo` sample policy gains `$grant: 'foo.*'` and `$deny: (req) => req.suspended === true`.

## Docs

`DOCUMENTATION.md` gains a "The `$grant` and `$deny` rules" section (+ TOC entry); `CHANGELOG.md` updated under Unreleased.

## Notes

The `example-*` CI jobs fail on the unrelated `bcrypt@3` dep rot (non-gating, still mergeable).