### PR TITLE
Run CI on Node 24 and declare supported engines (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pull request template (`.github/PULL_REQUEST_TEMPLATE.md`).
 - Explicit `types` and `files` fields in `package.json` so the published
   package ships only `lib/` and `index.js`.
+- The library CI matrix now also runs on Node 24, and an `engines` field
+  declares the supported floor (`node >= 18`).
 - `$not` and `$nor` logical operators in policy rules, and implicit AND across
   the multiple keys of a policy object.
 - `validatePermissions()` and `getAllPermissionsFor()` now accept the system

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "/lib",
     "/index.js"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Closes #6.

## What Changed

- Added **Node 24** (current LTS) to the library CI matrix, now `[18, 20, 22, 24]`, for broader regression coverage.
- Added an **`engines`** field to `package.json` declaring the supported floor: `node >= 18`.

## Why

#6 asked to run CI against additional Node versions. This broadens upward to the current LTS and records the supported range explicitly.

Versions below 18 are all end-of-life, so they are intentionally not added — gating CI on dead runtimes adds noise without real coverage value (and the example apps already can't build on them due to their legacy native deps).

## How to Test

CI runs the lib lint/build/test on each matrix version automatically on this PR.

## Notes

The `example-*` jobs remain non-gating and still fail on the unrelated `bcrypt@3` dep rot.