### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-09
+
 ### Added
 
 - `CHANGELOG.md` following Keep a Changelog + Semantic Versioning.
@@ -66,5 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policies, and an `authorize` middleware, with MongoDB and PostgreSQL example
   applications.
 
-[Unreleased]: https://github.com/mutaimwiti/rbactl/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/mutaimwiti/rbactl/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/mutaimwiti/rbactl/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mutaimwiti/rbactl/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbactl",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Easy and intuitive role-based access control library for Express apps.",
   "main": "index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Release prep for **0.2.0**.

## What Changed

- Bump `version` `0.1.0 → 0.2.0` in `package.json`.
- Finalize `CHANGELOG.md`: roll the `[Unreleased]` section into `[0.2.0] - 2026-06-09`, add a fresh empty `[Unreleased]`, and update the compare links.

## Release contents (0.2.0)

- **Shipped TypeScript types** (headline) — the library is now written in TS and ships generated declarations.
- logical-compiler policy evaluator (nested-promise + multi-key fixes).
- `$grant` / `$deny` entity override rules.
- `$not` / `$nor` operators and implicit AND.
- `validatePermissions()` / `getAllPermissionsFor()` accept a plain permission array.
- GitHub-native dev/release tooling, CI on Node 18/20/22/24, `engines` floor.

## Next steps after merge

1. Promote `develop → master`.
2. `npm publish` from `master`.
3. `yarn release` cuts the `v0.2.0` GitHub release (publish-first) with these changelog notes + `lib.zip`.

## How to Test

`yarn build && yarn lint && yarn test` — green (87 tests). `node scripts/release.mjs --dry-run` (from `master`) will print the extracted `0.2.0` notes.