### PR TITLE
Prepare 0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-09
+
+### Removed
+
+- GitLab mirror references in the README. The project now lives solely on
+  GitHub (the GitLab repository has been archived).
+
 ## [0.2.1] - 2026-06-09
 
 ### Changed
@@ -79,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policies, and an `authorize` middleware, with MongoDB and PostgreSQL example
   applications.
 
-[Unreleased]: https://github.com/mutaimwiti/rbactl/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/mutaimwiti/rbactl/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/mutaimwiti/rbactl/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/mutaimwiti/rbactl/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mutaimwiti/rbactl/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mutaimwiti/rbactl/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbactl",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Easy and intuitive role-based access control library for Express apps.",
   "main": "index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Patch release publishing the GitLab-free README. Removes the GitLab mirror references; the published library code is unchanged since 0.2.0. After merge: `npm publish` from master, then `yarn release` cuts v0.2.2.